### PR TITLE
Fix: Install libgomp1 to resolve LightGBM import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.10-slim
 # Establece el directorio de trabajo
 WORKDIR /app
 
+# Instala libgomp1
+RUN apt-get update && apt-get install -y libgomp1
+
 # Copia los archivos de requerimientos e instálalos
 COPY requirements.txt ./
 RUN pip install --upgrade pip && \


### PR DESCRIPTION
The application was crashing on Railway due to an OSError when LightGBM attempted to load libgomp.so.1. This library was missing in the Docker environment.

This commit updates the Dockerfile to install libgomp1 using apt-get, ensuring that LightGBM and its dependencies can be loaded correctly.